### PR TITLE
Add commentstring and comments settings

### DIFF
--- a/ftplugin/elm.vim
+++ b/ftplugin/elm.vim
@@ -21,6 +21,9 @@ endif
 
 setlocal omnifunc=elm#Complete
 
+setlocal comments=:--
+setlocal commentstring=--\ %s
+
 " Commands
 command -buffer -nargs=? -complete=file ElmMake call elm#Make(<f-args>)
 command -buffer ElmMakeMain call elm#Make("Main.elm")


### PR DESCRIPTION
`commentstring` is needed to work with @tpope's vim-commentary
(https://github.com/tpope/vim-commentary)

Thank you for making this – it's neat!