### PR TITLE
Completion fixes

### DIFF
--- a/autoload/elm.vim
+++ b/autoload/elm.vim
@@ -198,7 +198,7 @@ fun! elm#Complete(findstart, base)
 			let start = idx
 		endif
 
-		let s:fullComplete = line[idx : col('.')-1]
+		let s:fullComplete = line[idx : col('.')-2]
 
 		return start
 	else

--- a/autoload/elm.vim
+++ b/autoload/elm.vim
@@ -69,6 +69,11 @@ fun! s:elmOracle(...)
 	endif
 
 	let infos = system("elm-oracle " . filename . " " . word)
+        if v:shell_error != 0
+          echo "elm-oracle failed:\n\n" . infos
+          return []
+        endif
+
 	let d = split(infos, '\n')
 	if len(d) > 0
 		return s:DecodeJSON(d[0])


### PR DESCRIPTION
commit 1 fixes an off-by-one that caused incorrect completions and/or crashes

commit 2 makes the crashes behave a bit better (they can still happen if e.g. you're not in an elm package when editing, which I'd also like to fix later)