### PR TITLE
find elm-stuff relative to file; err if not found

### DIFF
--- a/autoload/elm.vim
+++ b/autoload/elm.vim
@@ -57,7 +57,13 @@ function! s:OpenBrowser(url)
 endfunction
 
 fun! s:elmOracle(...)
-	let filename = expand("%")
+	let project = finddir("elm-stuff/..", ".;")
+	if len(project) == 0
+		echoerr "`elm-stuff` not found! run `elm-package install` for autocomplete."
+		return []
+	endif
+
+	let filename = expand("%:p")
 
 	if a:0 == 0
 		let oldiskeyword = &iskeyword
@@ -68,7 +74,7 @@ fun! s:elmOracle(...)
 		let word = a:1
 	endif
 
-	let infos = system("elm-oracle " . filename . " " . word)
+	let infos = system("cd " . project . " && elm-oracle " . filename . " " . word)
         if v:shell_error != 0
           echo "elm-oracle failed:\n\n" . infos
           return []


### PR DESCRIPTION
(more detail in the commit message)

This makes autocomplete work regardless of the user's working directory, by finding the package's root dir by looking for `elm-stuff` in parent directories of the file.

If it can't find it it raises an error. I'd prefer that to be less disruptive but don't know a great way of showing warnings in vim while in insert mode. It's at least a nicer error now. :)