### PR TITLE
Highlight True and False as normal union types

### DIFF
--- a/syntax/elm.vim
+++ b/syntax/elm.vim
@@ -14,9 +14,6 @@ syn match elmBacktick "`[A-Za-z][A-Za-z0-9_]*\('\)*`"
 " Types
 syn match elmType "\<[A-Z][0-9A-Za-z_'-]*"
 
-" Booleans
-syn keyword elmBoolean True False otherwise
-
 " Delimiters
 syn match elmDelimiter  "[(),;[\]{}]"
 
@@ -49,7 +46,6 @@ hi def link elmKeyword Keyword
 hi def link elmOperator Operator
 hi def link elmBacktick Operator
 hi def link elmTupleFunction Normal
-hi def link elmBoolean Boolean
 hi def link elmType Type
 hi def link elmTodo Todo
 hi def link elmLineComment Comment


### PR DESCRIPTION
Although other languages have special language keywords for `true` and `false`, Elm implements `True` and `False` as plain old union types. Highlighting them differently than (for example) `Nothing` or `Result` or `Task` subtly suggests they play by different rules than other union types, when they actually do not.

This PR makes the formatting consistent across union types by removing the special case for `True` and `False`, and also removes special highlighting for `otherwise`, as `otherwise` was removed from Core in 3.0.0. :smiley: 