### PR TITLE
Allow messages to be echoed later

### DIFF
--- a/autoload/elm.vim
+++ b/autoload/elm.vim
@@ -65,7 +65,7 @@ fun! elm#Format()
 		let &fileformat = old_fileformat
 		let &syntax = &syntax
 	else
-		call elm#util#EchoError("elm-format:", out)
+		call elm#util#EchoLater("EchoError", "elm-format:", out)
 	endif
 
 	" restore our cursor/windows positions, folds, etc..

--- a/autoload/elm/util.vim
+++ b/autoload/elm/util.vim
@@ -88,3 +88,19 @@ endf
 fun! elm#util#EchoError(title, msg)
 	redraws! | echon a:title . " " | echohl ErrorMsg | echon a:msg | echohl None
 endf
+
+fun! elm#util#EchoLater(func_name, title, msg)
+  let s:echo_func_name = a:func_name
+  let s:echo_title = a:title
+  let s:echo_msg = a:msg
+endf
+
+fun! elm#util#EchoStored()
+  if exists('s:echo_func_name') && exists('s:echo_title') && exists('s:echo_msg')
+    call function('elm#util#' . s:echo_func_name)(s:echo_title, s:echo_msg)
+    unlet s:echo_func_name
+    unlet s:echo_title
+    unlet s:echo_msg
+  endif
+endf
+

--- a/ftplugin/elm.vim
+++ b/ftplugin/elm.vim
@@ -72,6 +72,7 @@ endif
 " Elm code formatting on save
 if get(g:, "elm_format_autosave", 1)
 	autocmd BufWritePre *.elm call elm#Format()
+	autocmd BufWritePost *.elm call elm#util#EchoStored()
 endif
 
 " Enable go to file under cursor from module name


### PR DESCRIPTION
`elm#Format()` is triggered pre write of a buffer. This causes echoed
messages to be cleared before the user actually sees them. By storing
messages for later use, using `elm#util#EchoLater` we can overcome this
problem.

This pull request addresses issue #57

Extra thanks to @Raimondi for helping me figuring this one out!