### PR TITLE
Only show elm-format error if syntastic is disabled

### DIFF
--- a/autoload/elm.vim
+++ b/autoload/elm.vim
@@ -106,6 +106,39 @@ fun! elm#BrowseDocs()
 	endif
 endf
 
+
+fun! elm#InferType()
+	let bin = "elm-make"
+	let format = "--report=json"
+	let input = shellescape(expand("%"))
+	let output = "--output=/dev/null"
+	let command = bin . " " . format  . " " . input . " " . output
+	let reports = s:ExecuteInRoot(command)
+
+	for report in split(reports, '\n')
+		if report[0] == '['
+			for error in elm#util#DecodeJSON(report)
+				if error.tag == "missing type annotation"
+					if error.file == expand("%")
+						if error.region.start.line == line(".")
+							let chunks = split(error.details, "\n")
+							let signature = chunks[len(chunks) - 1]
+							return signature
+						end
+					end
+				end
+			endfor
+		endif
+	endfor
+endfun
+
+fun! elm#InsertInferredType()
+	let signature = elm#InferType()
+	if signature != "0"
+		call append(line('.') - 1, signature)
+	end
+endfun
+
 fun! elm#Build(input, output, show_warnings)
 	let s:errors = []
 	let fixes = []

--- a/autoload/elm.vim
+++ b/autoload/elm.vim
@@ -64,7 +64,7 @@ fun! elm#Format()
 		silent edit!
 		let &fileformat = old_fileformat
 		let &syntax = &syntax
-	else
+	elseif g:elm_syntastic_show_warnings == 0
 		call elm#util#EchoError("elm-format:", out)
 	endif
 

--- a/autoload/elm.vim
+++ b/autoload/elm.vim
@@ -139,6 +139,13 @@ fun! elm#InsertInferredType()
 	end
 endfun
 
+fun! elm#ShowInferredType()
+	let signature = elm#InferType()
+	if signature != "0"
+		call elm#util#Echo("Inferred Type:", signature)
+	end
+endfun
+
 fun! elm#Build(input, output, show_warnings)
 	let s:errors = []
 	let fixes = []

--- a/ftplugin/elm.vim
+++ b/ftplugin/elm.vim
@@ -49,6 +49,7 @@ command -buffer ElmErrorDetail call elm#ErrorDetail()
 command -buffer ElmShowDocs call elm#ShowDocs()
 command -buffer ElmBrowseDocs call elm#BrowseDocs()
 command -buffer ElmFormat call elm#Format()
+command -buffer ElmInsertInferredType call elm#InsertInferredType()
 
 " Mappings
 nnoremap <silent> <Plug>(elm-make) :<C-u>call elm#Make()<CR>

--- a/ftplugin/elm.vim
+++ b/ftplugin/elm.vim
@@ -50,6 +50,7 @@ command -buffer ElmShowDocs call elm#ShowDocs()
 command -buffer ElmBrowseDocs call elm#BrowseDocs()
 command -buffer ElmFormat call elm#Format()
 command -buffer ElmInsertInferredType call elm#InsertInferredType()
+command -buffer ElmShowInferredType call elm#ShowInferredType()
 
 " Mappings
 nnoremap <silent> <Plug>(elm-make) :<C-u>call elm#Make()<CR>


### PR DESCRIPTION
Hi Joseph,

At present, syntax errors cause elm-format to fail, outputting a nasty
red error which is immediately replaced by a syntastic error (presumably
saying exactly the same thing) in the quickfix box.

To prevent this I have added the additional condition that elm-format
only shows errors if syntastic is disabled.

I am not sure if this is a sensible solution to the issue, there are
conceivably errors that can occur with elm-format that aren't related to
syntax (i.e. filesystem errors). I thought it best to make a pull request
regardless as this is how I've dealt with the issue locally, and then you
can at least think about it.

Hope that this is all ok.

Rohan