### PR TITLE
Set up include option

### DIFF
--- a/ftplugin/elm.vim
+++ b/ftplugin/elm.vim
@@ -92,4 +92,5 @@ let &l:path =
       \   &g:path
       \ ], ',')
 setlocal includeexpr=GetElmFilename(v:fname)
+setlocal include=^\\s*import\\s\\+
 setlocal suffixesadd=.elm


### PR DESCRIPTION
This allows path-searching functions like `[I` to know which files are
included, so it knows which files to search