### PR TITLE
Feature show/insert inferred types

### DIFF
--- a/autoload/elm.vim
+++ b/autoload/elm.vim
@@ -106,6 +106,39 @@ fun! elm#BrowseDocs()
 	endif
 endf
 
+
+fun! elm#InferType()
+	let bin = "elm-make"
+	let format = "--report=json"
+	let input = shellescape(expand("%"))
+	let output = "--output=/dev/null"
+	let command = bin . " " . format  . " " . input . " " . output
+	let reports = s:ExecuteInRoot(command)
+
+	for report in split(reports, '\n')
+		if report[0] == '['
+			for error in elm#util#DecodeJSON(report)
+				if error.tag == "missing type annotation"
+					if error.file == expand("%")
+						if error.region.start.line == line(".")
+							let chunks = split(error.details, "\n")
+							let signature = chunks[len(chunks) - 1]
+							return signature
+						end
+					end
+				end
+			endfor
+		endif
+	endfor
+endfun
+
+fun! elm#InsertInferredType()
+	let signature = elm#InferType()
+	if signature != "0"
+		call append(line('.') - 1, signature)
+	end
+endfun
+
 fun! elm#Build(input, output, show_warnings)
 	let s:errors = []
 	let fixes = []

--- a/autoload/elm.vim
+++ b/autoload/elm.vim
@@ -121,9 +121,14 @@ fun! elm#InferType()
 				if error.tag == "missing type annotation"
 					if error.file == expand("%")
 						if error.region.start.line == line(".")
-							let chunks = split(error.details, "\n")
-							let signature = chunks[len(chunks) - 1]
-							return signature
+							let l:msg = error.details
+							let l:fn_name = split(getline("."))[0]
+							let l:pattern =  "\n" . l:fn_name
+							let l:starting_index = match(l:msg, l:pattern) + 1
+							let l:signature = strpart(l:msg, l:starting_index)
+							let l:singleline_sig = substitute(l:signature, "\n", "", "g")
+							let l:singlespaced_sig = substitute(l:singleline_sig, ' \+', " ", "g")
+							return l:singlespaced_sig
 						end
 					end
 				end

--- a/autoload/elm.vim
+++ b/autoload/elm.vim
@@ -139,6 +139,13 @@ fun! elm#InsertInferredType()
 	end
 endfun
 
+fun! elm#ShowInferredType()
+	let signature = elm#InferType()
+	if signature != "0"
+		call elm#util#Echo("Inferred Type:", signature)
+	end
+endfun
+
 fun! elm#Build(input, output, show_warnings)
 	let s:errors = []
 	let fixes = []

--- a/ftplugin/elm.vim
+++ b/ftplugin/elm.vim
@@ -49,6 +49,7 @@ command -buffer ElmErrorDetail call elm#ErrorDetail()
 command -buffer ElmShowDocs call elm#ShowDocs()
 command -buffer ElmBrowseDocs call elm#BrowseDocs()
 command -buffer ElmFormat call elm#Format()
+command -buffer ElmInsertInferredType call elm#InsertInferredType()
 
 " Mappings
 nnoremap <silent> <Plug>(elm-make) :<C-u>call elm#Make()<CR>

--- a/ftplugin/elm.vim
+++ b/ftplugin/elm.vim
@@ -50,6 +50,7 @@ command -buffer ElmShowDocs call elm#ShowDocs()
 command -buffer ElmBrowseDocs call elm#BrowseDocs()
 command -buffer ElmFormat call elm#Format()
 command -buffer ElmInsertInferredType call elm#InsertInferredType()
+command -buffer ElmShowInferredType call elm#ShowInferredType()
 
 " Mappings
 nnoremap <silent> <Plug>(elm-make) :<C-u>call elm#Make()<CR>


### PR DESCRIPTION
Hi,

I wrote a couple of functions that either echo or insert the inferred type signature for the function under the cursor, like `_t` and `_T` in haskellmode-vim plugin.

 Apologies in advance, my vimscript skills are pretty shoddy :(
