### PR TITLE
Only show elm format error if syntastic is disabled

### DIFF
--- a/autoload/elm.vim
+++ b/autoload/elm.vim
@@ -64,7 +64,7 @@ fun! elm#Format()
 		silent edit!
 		let &fileformat = old_fileformat
 		let &syntax = &syntax
-	else
+	elseif g:elm_syntastic_show_warnings == 0
 		call elm#util#EchoError("elm-format:", out)
 	endif
 


### PR DESCRIPTION
Hi Joseph,

At present, syntax errors cause elm-format to fail, outputting a nasty
red error which is immediately replaced by a syntastic error (presumably
saying exactly the same thing) in the quickfix box.

To prevent this I have added the additional condition that elm-format
only shows errors if syntastic is disabled.

I am not sure if this is a sensible solution to the issue, there are
conceivably errors that can occur with elm-format that aren't related to
syntax (i.e. filesystem errors). I thought it best to make a pull request
regardless as this is how I've dealt with the issue locally, and then you
can at least think about it.

Hope that this is all ok.

Rohan

(sorry, posted my master branch for previous pull request!!)