### PR TITLE
show spelling errors in strings

### DIFF
--- a/syntax/elm.vim
+++ b/syntax/elm.vim
@@ -32,8 +32,8 @@ syn region elmComment matchgroup=elmComment start="{-|\=" end="-}" contains=elmT
 " Strings
 syn match elmStringEscape "\\u[0-9a-fA-F]\{4}" contained
 syn match elmStringEscape "\\[nrfvbt\\\"]" contained
-syn region elmString start="\"" skip="\\\"" end="\"" contains=elmStringEscape
-syn region elmTripleString start="\"\"\"" skip="\\\"" end="\"\"\"" contains=elmStringEscape
+syn region elmString start="\"" skip="\\\"" end="\"" contains=elmStringEscape,@spell
+syn region elmTripleString start="\"\"\"" skip="\\\"" end="\"\"\"" contains=elmStringEscape,@spell
 syn match elmChar "'[^'\\]'\|'\\.'\|'\\u[0-9a-fA-F]\{4}'"
 
 " Numbers


### PR DESCRIPTION
Since strings are usually intended for display, I want spelling errors to show up in my strings when I have spell an syntax highlighting on.  Added to both single and triple quoted strings.