### PR TITLE
Prevent deindentation when previous line is empty

### DIFF
--- a/indent/elm.vim
+++ b/indent/elm.vim
@@ -102,6 +102,8 @@ function! GetElmIndent()
 	elseif line =~ '^\s*\(!\|&\|(\|`\|+\||\|{\|[\|,\)' && lline !~ '^\s*\(!\|&\|(\|`\|+\||\|{\|[\|,\)' && lline !~ '^\s*$'
 		let ind = ind + &sw
 
+	elseif lline ==# ''
+		return indent(search('^\s*\S+', 'bWn'))
 	endif
 
 	return ind

--- a/syntax/elm.vim
+++ b/syntax/elm.vim
@@ -54,7 +54,7 @@ hi def link elmChar String
 hi def link elmStringEscape Special
 hi def link elmInt Number
 hi def link elmFloat Float
-hi def link elmDelimiter Comment
+hi def link elmDelimiter Delimiter
 
 if get(g:, "elm_classic_highlighting", 1)
 	hi def link elmTypedef Keyword
@@ -70,7 +70,7 @@ else
 	hi def link elmImport Include
 	hi def link elmConditional Conditional
 	hi def link elmAlias StorageClass
-	hi def link elmOperator Comment
+	hi def link elmOperator Character
 	hi def link elmType Identifier
 	hi def link elmNumberType Identifier
 	hi def link elmBraces Delimiter


### PR DESCRIPTION
Currently, the plugin goes to 0 indentation if the line before it is empty which is annoying when trying to add whitespace between things like case statements.

This pull request adds an extra condition which checks if the current line is empty and if so, uses the indentation level of the last line that contains something that is not whitespace.