### PR TITLE
optional two spaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ let g:elm_detailed_complete = 0
 let g:elm_format_autosave = 0
 let g:elm_format_fail_silently = 0
 let g:elm_setup_keybindings = 1
+let g:elm_format_two_spaces = 1
 ```
 
 * `:ElmMake [filename]` calls `elm-make` with the given file. If no file is given it uses the current file being edited.

--- a/autoload/elm.vim
+++ b/autoload/elm.vim
@@ -62,6 +62,9 @@ fun! elm#Format()
 		let old_fileformat = &fileformat
 		call rename(l:tmpname, expand('%'))
 		silent edit!
+    if g:elm_format_two_spaces == 1
+      %s;^\(\s\+\);\=repeat(' ', len(submatch(0))/2);g
+    endif
 		let &fileformat = old_fileformat
 		let &syntax = &syntax
 	elseif g:elm_format_fail_silently == 0


### PR DESCRIPTION
I personally sometimes do not have the screen real estate for four spaces and prefer not to have to type backspace twice as many times as necessary, and I think you can read code perfectly fine with two spaces, so I modified my elm-vim to allow people to have two spaces instead of four...with this pr, everyone could have this.