### PR TITLE
Fixes #80 Trailing characters error with elm-format on save

### DIFF
--- a/autoload/elm/util.vim
+++ b/autoload/elm/util.vim
@@ -102,7 +102,7 @@ endf
 
 fun! elm#util#EchoStored()
   if exists('s:echo_func_name') && exists('s:echo_title') && exists('s:echo_msg')
-    call function('elm#util#' . s:echo_func_name)(s:echo_title, s:echo_msg)
+    call elm#util#{s:echo_func_name}(s:echo_title, s:echo_msg)
     unlet s:echo_func_name
     unlet s:echo_title
     unlet s:echo_msg


### PR DESCRIPTION
This fixed #80 for me on:

OS X 10.11.6
VIM 7.3

From `:help :call`:

> You can call and define functions by an evaluated name [...]
Example:
:let func_end='whizz'
:call my_func_{func_end}(parameter)