### PR TITLE
Replace the current ElmFormat with a more lightweight version

### DIFF
--- a/autoload/elm.vim
+++ b/autoload/elm.vim
@@ -44,49 +44,9 @@ fun! elm#Format()
 		return
 	endif
 
-	" save cursor position, folds and many other things
-    let l:curw = {}
-    try
-      mkview!
-    catch
-      let l:curw = winsaveview()
-    endtry
-
-    " save our undo file to be restored after we are done.
-    let tmpundofile = tempname()
-    exe 'wundo! ' . tmpundofile
-
-	" write current unsaved buffer to a temporary file
-	let l:tmpname = tempname() . ".elm"
-	call writefile(getline(1, '$'), l:tmpname)
-
-	" call elm-format on the temporary file
-	let out = system("elm-format " . l:tmpname . " --output " . l:tmpname)
-
-	" if there is no error
-	if v:shell_error == 0
-		try | silent undojoin | catch | endtry
-
-		" replace current file with temp file, then reload buffer
-		let old_fileformat = &fileformat
-		call rename(l:tmpname, expand('%'))
-		silent edit!
-		let &fileformat = old_fileformat
-		let &syntax = &syntax
-	elseif g:elm_format_fail_silently == 0
-		call elm#util#EchoLater("EchoError", "elm-format:", out)
-	endif
-
-    " save our undo history
-    silent! exe 'rundo ' . tmpundofile
-    call delete(tmpundofile)
-
-	" restore our cursor/windows positions, folds, etc..
-    if empty(l:curw)
-      silent! loadview
-    else
-      call winrestview(l:curw)
-    endif
+    let l:curw = winsaveview()
+    :%! elm-format --stdin
+    call winrestview(l:curw)
 endf
 
 " Query elm-oracle and echo the type and docs for the word under the cursor.


### PR DESCRIPTION
I was running into a lot of issues with the current implementation of
the ElmFormat command. Whenever I would format my source code it would
kick off builds on my webpack dev server. In addition, when you have a
NERDTree window open along with a Tagbar window, there is a lot of
loading/unloading happening and all of the windows jump around.

This version of ElmFormat doesn't use any temporary files or write to
the file system, it just replaces the current buffer with the output of
elm-format. The error messages are not displayed in a particularly fancy
way, but the buffer change is represented in the undo history and in
practice the workflow is pretty functional: attempt to format, see the
error, undo and fix it. Sort of a light weight syntax check without
needing to use elm-make, which requires that imports are actually
resolved and you're in a proper project, etc.