### PR TITLE
Add new ctags kinds for tagbar

### DIFF
--- a/ftplugin/elm/tagbar.vim
+++ b/ftplugin/elm/tagbar.vim
@@ -9,6 +9,8 @@ function! s:SetTagbar()
         let g:tagbar_type_elm = {
                     \ 'ctagstype' : 'elm',
                     \ 'kinds'     : [
+                    \ 't:types',
+                    \ 'a:type aliases',
                     \ 'c:constants',
                     \ 'f:functions',
                     \ 'p:ports'


### PR DESCRIPTION
Was excited to see your update on elm-vim including tagbar spport. Thanks!
I've [extended ctags-elm](https://github.com/kbsymanz/ctags-elm/pull/2) to include `type` and `type alias` tag kinds. And added them to the tagbar support here. 

 