### PR TITLE
Add support for ElmErrorDetail when using syntastic

### DIFF
--- a/autoload/elm.vim
+++ b/autoload/elm.vim
@@ -140,6 +140,7 @@ function! elm#Syntastic(input) abort
                 if g:elm_syntastic_show_warnings == 0 && l:error.type ==? 'warning'
                 else
                     if a:input == l:error.file
+                        call add(s:errors, l:error)
                         call add(l:fixes, {'filename': l:error.file,
                                     \'valid': 1,
                                     \'bufnr': bufnr('%'),


### PR DESCRIPTION
Current implementation of `elm#Syntastic` does not populate `s:errors`, causing `ElmErrorDetail` to show nothing/outdated details. 

Fixes #106.