### PR TITLE
Ensure vim hooks are registered only once

### DIFF
--- a/ftplugin/elm.vim
+++ b/ftplugin/elm.vim
@@ -63,6 +63,7 @@ endif
 " Elm code formatting on save
 if get(g:, 'elm_format_autosave', 1)
   augroup elmFormat
+	autocmd!
 	autocmd BufWritePre *.elm call elm#Format()
 	autocmd BufWritePost *.elm call elm#util#EchoStored()
    augroup END


### PR DESCRIPTION
I noticed that the longer vim ran, the slower the elm-format upon save functionality seemed to become. It turns out the cause of this is that for every .elm file that is opened, a new set of BufWrite hooks is registered. This means that after navigating around the project a bit, saving a file is going to invoke elm-format multiple times in succession, which is slow and pointless.

This PR fixes that by always clearing the relevant commit hooks before registering them again.