### PR TITLE
Indentation Fixes

### DIFF
--- a/indent/elm.vim
+++ b/indent/elm.vim
@@ -80,7 +80,7 @@ function! GetElmIndent()
 		return l:ind + 4
 
 	" Align bindings with the parent in.
-	elseif l:lline =~# '^\s*in'
+	elseif l:lline =~# '^\s*in\>'
 		return l:ind + 4
 
 	endif

--- a/indent/elm.vim
+++ b/indent/elm.vim
@@ -99,7 +99,7 @@ function! GetElmIndent()
 		let l:ind = indent(searchpair('{-', '', '-}', 'bWn', 'synIDattr(synID(line("."), col("."), 0), "name") =~? "string"'))
 
 	" Ident some operators if there aren't any starting the last line.
-	elseif l:line =~# '^\s*\(!\|&\|(\|`\|+\||\|{\|[\|,\)' && l:lline !~# '^\s*\(!\|&\|(\|`\|+\||\|{\|[\|,\)' && l:lline !~# '^\s*$'
+	elseif l:line =~# '^\s*\(!\|&\|(\|`\|+\||\|{\|[\|,\)=' && l:lline !~# '^\s*\(!\|&\|(\|`\|+\||\|{\|[\|,\)=' && l:lline !~# '^\s*$'
 		let l:ind = l:ind + &shiftwidth
 
 	elseif l:lline ==# '' && getline(l:lnum - 1) !=# ''


### PR DESCRIPTION
There are some small indentation bugs that don't conform to the elm style guide and in some cases can actually lead to code that doesn't compile.

According to the [style guide](http://elm-lang.org/docs/style-guide), multi-line union types should have the following indentation:
```
type Boolean
    = Literal Bool
    | Not Boolean
    | And Boolean Boolean
    | Or Boolean Boolean
```
Due to an omitted `=` operator in a regex, elm-vim was indenting this as:
```
type Boolean
    = Literal Bool
        | Not Boolean
        | And Boolean Boolean
        | Or Boolean Boolean
```
This has been fixed by amending the regex.


There was also a missing word boundary near one of the indentation checks for the `in` keyword. This was causing function names with `in` as a prefix to indent if there is a type annotation on the line above it (this causes a compilation error). Since the elm architecture uses a function called `init`, this can unintentionally break a lot of stuff.