### PR TITLE
Improve gf command

### DIFF
--- a/autoload/elm.vim
+++ b/autoload/elm.vim
@@ -342,7 +342,7 @@ function! elm#Test() abort
 endf
 
 " Returns the closest parent with an elm-package.json file.
-function! s:FindRootDirectory() abort
+function! elm#FindRootDirectory() abort
 	let l:elm_root = getbufvar('%', 'elmRoot')
 	if empty(l:elm_root)
 		let l:current_file = expand('%:p')
@@ -365,7 +365,7 @@ endfunction
 function! s:ExecuteInRoot(cmd) abort
 	let l:cd = exists('*haslocaldir') && haslocaldir() ? 'lcd ' : 'cd '
 	let l:current_dir = getcwd()
-	let l:root_dir = s:FindRootDirectory()
+	let l:root_dir = elm#FindRootDirectory()
 
 	try
 		execute l:cd . fnameescape(l:root_dir)

--- a/ftplugin/elm.vim
+++ b/ftplugin/elm.vim
@@ -60,6 +60,9 @@ if get(g:, 'elm_setup_keybindings', 1)
   nmap <buffer> <LocalLeader>w <Plug>(elm-browse-docs)
 endif
 
+" Better gf command
+nmap gf :call elm#util#GoToModule(expand('<cfile>'))<CR>
+
 " Elm code formatting on save
 if get(g:, 'elm_format_autosave', 1)
   augroup elmFormat
@@ -85,8 +88,8 @@ endfunction
 
 let &l:path =
       \ join([
-      \   getcwd().'/src',
-      \   getcwd().'/elm-stuff/packages/**/src',
+      \   elm#FindRootDirectory().'/src',
+      \   elm#FindRootDirectory().'/elm-stuff/packages/**/src',
       \   &g:path
       \ ], ',')
 setlocal includeexpr=GetElmFilename(v:fname)


### PR DESCRIPTION
I depend on `gf` a lot to navigate around a project, but noticed it doesn't behave as expected under certain circumstances. This PR makes `gf` behave correctly under almost all circumstances, at least that is my experience trying it out on a large Elm project.

In particular it fixes these issues:
- Works regardless of current working directory.
- Finds module shadowed by a directory with the same name.
- Finds modules outside of the /src directory.
- Finds native modules.

Implementation requires a custom binding of `gf` in .elm files. This is an approach also taken by plugins like `vim-rails` and `vim-node`.