### PR TITLE
make custom gf mapping buffer local

### DIFF
--- a/ftplugin/elm.vim
+++ b/ftplugin/elm.vim
@@ -61,7 +61,7 @@ if get(g:, 'elm_setup_keybindings', 1)
 endif
 
 " Better gf command
-nmap gf :call elm#util#GoToModule(expand('<cfile>'))<CR>
+nmap <buffer> gf :call elm#util#GoToModule(expand('<cfile>'))<CR>
 
 " Elm code formatting on save
 if get(g:, 'elm_format_autosave', 1)


### PR DESCRIPTION
The `gf` mapping should be buffer local, otherwise it clobbers the normal built-in behaviour of `gf` while editing other non-elm files in the same vim session.