### PR TITLE
docs(README): fix key mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,13 +53,13 @@ mappings. The following keybindings are provided by default:
 
 | Keybinding             | Description                                                         |
 | ---------------------- | ------------------------------------------------------------------- |
-| \<Leader>m              | Compile the current buffer.                                        |
-| \<Leader>b              | Compile the Main.elm file in the project.                          |
-| \<Leader>t              | Runs the tests of the current buffer or 'tests/TestRunner'.                              |
-| \<Leader>r              | Opens an elm repl in a subprocess.                                 |
-| \<Leader>e              | Shows the detail of the current error or warning.                  |
-| \<Leader>d              | Shows the type and docs for the word under the cursor.             |
-| \<Leader>w              | Opens the docs web page for the word under the cursor.             |
+| \<LocalLeader>m              | Compile the current buffer.                                        |
+| \<LocalLeader>b              | Compile the Main.elm file in the project.                          |
+| \<LocalLeader>t              | Runs the tests of the current buffer or 'tests/TestRunner'.                              |
+| \<LocalLeader>r              | Opens an elm repl in a subprocess.                                 |
+| \<LocalLeader>e              | Shows the detail of the current error or warning.                  |
+| \<LocalLeader>d              | Shows the type and docs for the word under the cursor.             |
+| \<LocalLeader>w              | Opens the docs web page for the word under the cursor.             |
 
 You can disable these mappings if you want to use your own.
 
@@ -123,7 +123,7 @@ let g:elm_setup_keybindings = 1
 
 * `:ElmMakeMain` attempts to call `elm-make` with "Main.elm".
 
-* `:ElmTest` calls `elm-test` with the given file. If no file is given it runs it in the root of your project. 
+* `:ElmTest` calls `elm-test` with the given file. If no file is given it runs it in the root of your project.
 
 * `:ElmRepl` runs `elm-repl`, which will return to vim on exiting.
 


### PR DESCRIPTION
### What problem does this PR solve?
In `README.md`, it is mentioned using `Leader` for key mappings.

But the plugin has been implemented by using `LocalLeader`. So the mapping won't work if we follow the documentation (README.md)

ref. https://github.com/ElmCast/elm-vim/blob/master/ftplugin/elm.vim#L54

### How does this PR solve it?
change Leader to LocalLeader in `README.md`