### PR TITLE
Support type annotations that span multiple lines

### DIFF
--- a/syntax/elm.vim
+++ b/syntax/elm.vim
@@ -41,7 +41,7 @@ syn match elmInt "-\?\<\d\+\>\|0[xX][0-9a-fA-F]\+\>"
 syn match elmFloat "\(\<\d\+\.\d\+\>\)"
 
 " Identifiers
-syn match elmTopLevelDecl "^\s*[a-zA-Z][a-zA-z0-9_]*\('\)*\s\+:\s\+" contains=elmOperator
+syn match elmTopLevelDecl "^\s*[a-zA-Z][a-zA-z0-9_]*\('\)*\s\+:" contains=elmOperator
 
 hi def link elmTopLevelDecl Function
 hi def link elmTupleFunction Normal


### PR DESCRIPTION
This adds support for function annotations that span multiple lines. Below is an example (generated by elm-format):

```elm
foo :
    String
    -> String    
```

Currently, the function name `foo` is not being highlighted. Removing the check for trailing whitespace was sufficient to fix this issue.