### PR TITLE
Fix indentation inconsistencies

### DIFF
--- a/indent/elm.vim
+++ b/indent/elm.vim
@@ -9,7 +9,7 @@ let b:did_indent = 1
 " Local defaults
 setlocal expandtab
 setlocal indentexpr=GetElmIndent()
-setlocal indentkeys+=0=else,0=if,0=of,0=import,0=then,0=type,0\|,0},0\],0),=-},0=in
+setlocal indentkeys+=0=else,0=if,0=of,0=import,0=then,0=type,0\|,0},0\],0),=-},0=in,0\=
 setlocal nolisp
 setlocal nosmartindent
 
@@ -89,17 +89,14 @@ function! GetElmIndent()
 	if l:lline =~# '\(|\|=\|->\|<-\|(\|\[\|{\|\<\(of\|else\|if\|then\)\)\s*$'
 		let l:ind = l:ind + &shiftwidth
 
-	" Add a 'shiftwidth' after lines starting with type ending with '=':
-	elseif l:lline =~# '^\s*type' && l:line =~# '^\s*='
-		let l:ind = l:ind + &shiftwidth
-
 	" Back to normal indent after comments:
 	elseif l:lline =~# '-}\s*$'
 		call search('-}', 'bW')
 		let l:ind = indent(searchpair('{-', '', '-}', 'bWn', 'synIDattr(synID(line("."), col("."), 0), "name") =~? "string"'))
 
 	" Ident some operators if there aren't any starting the last line.
-	elseif l:line =~# '^\s*\(!\|&\|(\|`\|+\||\|{\|[\|,\)=' && l:lline !~# '^\s*\(!\|&\|(\|`\|+\||\|{\|[\|,\)=' && l:lline !~# '^\s*$'
+	" Including '=' for Union types indentation
+	elseif l:line =~# '^\s*\(!\|&\|(\|`\|+\||\|{\|[\|,\|=\)' && l:lline !~# '^\s*\(!\|&\|(\|`\|+\||\|{\|[\|,\|=\)' && l:lline !~# '^\s*$'
 		let l:ind = l:ind + &shiftwidth
 
 	elseif l:lline ==# '' && getline(l:lnum - 1) !=# ''

--- a/indent/elm.vim
+++ b/indent/elm.vim
@@ -43,17 +43,9 @@ function! GetElmIndent()
 	if l:line =~? '^\s*}'
 		return s:FindPair('{', '', '}')
 
-	" Indent if current line begins with 'else':
+	" Align 'else' with the parent if.
 	elseif l:line =~# '^\s*else\>'
-		if l:lline !~# '^\s*\(if\|then\)\>'
-			return s:FindPair('\<if\>', '', '\<else\>')
-		endif
-
-	" Indent if current line begins with 'then':
-	elseif l:line =~# '^\s*then\>'
-		if l:lline !~# '^\s*\(if\|else\)\>'
-			return s:FindPair('\<if\>', '', '\<then\>')
-		endif
+		return indent(search('^\s*if', 'bWn'))
 
 	" HACK: Indent lines in case with nearest case clause:
 	elseif l:line =~# '->' && l:line !~# ':' && l:line !~# '\\'


### PR DESCRIPTION
resolves #128 . The proposed fix removes some code that I tried to manually test. The code was *probably* intended to do what my pull request does (but didn't work).

I manually tested the following cases:
 * Indentation on union types:
    ```elm
    type Bool
        = False
        | True
    ```
* The pipping operator:
    ```elm
    f x =
        tail x
            |> drop 5
            |> reverse
    ```
* The PR do not change the indentation behavior for certain operators:
    ```elm
    cathello x =
        x
        ++ "hello"
        ++ " world"
    ```
* Various `if else` expressions:
    ```elm
    if x > 10 then
        True
    else if x < 5 then
        False
    else
        True
    ```
    ```elm
    if x > 10
    then True
    else False
    ```
    ```elm
    if x > 10
    then True else False
    ```
    No situations seemed problematic, apart from nested `if else` with various levels of indentations. The same behavior showed in master.