### PR TITLE
Avoid warning from overwriting commands

### DIFF
--- a/ftplugin/elm.vim
+++ b/ftplugin/elm.vim
@@ -41,14 +41,14 @@ setlocal comments=:--
 setlocal commentstring=--\ %s
 
 " Commands
-command -buffer -nargs=? -complete=file ElmMake call elm#Make(<f-args>)
-command -buffer ElmMakeMain call elm#Make("Main.elm")
-command -buffer -nargs=? -complete=file ElmTest call elm#Test(<f-args>)
-command -buffer ElmRepl call elm#Repl()
-command -buffer ElmErrorDetail call elm#ErrorDetail()
-command -buffer ElmShowDocs call elm#ShowDocs()
-command -buffer ElmBrowseDocs call elm#BrowseDocs()
-command -buffer ElmFormat call elm#Format()
+command! -buffer -nargs=? -complete=file ElmMake call elm#Make(<f-args>)
+command! -buffer ElmMakeMain call elm#Make("Main.elm")
+command! -buffer -nargs=? -complete=file ElmTest call elm#Test(<f-args>)
+command! -buffer ElmRepl call elm#Repl()
+command! -buffer ElmErrorDetail call elm#ErrorDetail()
+command! -buffer ElmShowDocs call elm#ShowDocs()
+command! -buffer ElmBrowseDocs call elm#BrowseDocs()
+command! -buffer ElmFormat call elm#Format()
 
 if get(g:, 'elm_setup_keybindings', 1)
   nmap <buffer> <LocalLeader>m <Plug>(elm-make)


### PR DESCRIPTION
My colleague and I have been getting this warning every time we save an Elm file after installing this plugin.

![2017-09-27-121524_697x339_scrot](https://user-images.githubusercontent.com/6134406/30910727-d96a4332-a37d-11e7-8a90-a6a5caa26122.png)

I'm not well versed in VimL so I'm not sure if this is the best solution.