### PR TITLE
Update syntax to highlight function name

### DIFF
--- a/syntax/elm.vim
+++ b/syntax/elm.vim
@@ -42,6 +42,7 @@ syn match elmFloat "\(\<\d\+\.\d\+\>\)"
 
 " Identifiers
 syn match elmTopLevelDecl "^\s*[a-zA-Z][a-zA-z0-9_]*\('\)*\s\+:\(\r\n\|\r\|\n\|\s\)\+" contains=elmOperator
+syn match elmFuncName /^\l\w*/
 
 " Folding
 syn region elmTopLevelTypedef start="type" end="\n\(\n\n\)\@=" contains=ALL fold
@@ -50,6 +51,7 @@ syn region elmCaseBlock matchgroup=elmCaseBlockDefinition start="^\z\(\s\+\)\<ca
 syn region elmCaseItemBlock start="^\z\(\s\+\).\+->$" end="^\z1\@!\W\@=" end="\(\n\n\z1\@!\)\@=" end="\(\n\z1\S\)\@=" contains=ALL fold
 syn region elmLetBlock matchgroup=elmLetBlockDefinition start="\<let\>" end="\<in\>" contains=ALL fold
 
+hi def link elmFuncName Function
 hi def link elmCaseBlockDefinition Conditional
 hi def link elmCaseBlockItemDefinition Conditional
 hi def link elmLetBlockDefinition TypeDef


### PR DESCRIPTION
I noticed in other ML language syntax highlighters that the function name is highlighted (for instance see [Sublime's syntax](https://packagecontrol.io/packages/Elm%20Language%20Support)) which makes it useful to distinguish a function from its parameters.

The function name is only highlighted if it is not nested (i.e., at the beginning of the line) otherwise variables would be highlighted as functions.