### PR TITLE
Folding

### DIFF
--- a/syntax/elm.vim
+++ b/syntax/elm.vim
@@ -5,13 +5,13 @@ if exists('b:current_syntax')
 endif
 
 " Keywords
-syn keyword elmConditional case else if of then
+syn keyword elmConditional else if of then
 syn keyword elmAlias alias
-syn keyword elmTypedef type port let in
+syn keyword elmTypedef contained type port
 syn keyword elmImport exposing as import module where
 
 " Operators
-syn match elmOperator "\([-!#$%`&\*\+./<=>\?@\\^|~:]\|\<_\>\)"
+syn match elmOperator contained "\([-!#$%`&\*\+./<=>\?@\\^|~:]\|\<_\>\)"
 
 " Types
 syn match elmType "\<[A-Z][0-9A-Za-z_'-]*"
@@ -27,7 +27,7 @@ syn match elmTupleFunction "\((,\+)\)"
 " Comments
 syn keyword elmTodo TODO FIXME XXX contained
 syn match elmLineComment "--.*" contains=elmTodo,@spell
-syn region elmComment matchgroup=elmComment start="{-|\=" end="-}" contains=elmTodo,elmComment,@spell
+syn region elmComment matchgroup=elmComment start="{-|\=" end="-}" contains=elmTodo,elmComment,@spell fold
 
 " Strings
 syn match elmStringEscape "\\u[0-9a-fA-F]\{4}" contained
@@ -43,6 +43,16 @@ syn match elmFloat "\(\<\d\+\.\d\+\>\)"
 " Identifiers
 syn match elmTopLevelDecl "^\s*[a-zA-Z][a-zA-z0-9_]*\('\)*\s\+:\s\+" contains=elmOperator
 
+" Folding
+syn region elmTopLevelTypedef start="type" end="\n\(\n\n\)\@=" contains=ALL fold
+syn region elmTopLevelFunction start="^[a-zA-Z].\+\n[a-zA-Z].\+=" end="^\(\n\+\)\@=" contains=ALL fold
+syn region elmCaseBlock matchgroup=elmCaseBlockDefinition start="^\z\(\s\+\)\<case\>" end="^\z1\@!\W\@=" end="\(\n\n\z1\@!\)\@=" end="\n\z1\@!\(\n\n\)\@=" contains=ALL fold
+syn region elmCaseItemBlock start="^\z\(\s\+\).\+->$" end="^\z1\@!\W\@=" end="\(\n\n\z1\@!\)\@=" end="\(\n\z1\S\)\@=" contains=ALL fold
+syn region elmLetBlock matchgroup=elmLetBlockDefinition start="\<let\>" end="\<in\>" contains=ALL fold
+
+hi def link elmCaseBlockDefinition Conditional
+hi def link elmCaseBlockItemDefinition Conditional
+hi def link elmLetBlockDefinition TypeDef
 hi def link elmTopLevelDecl Function
 hi def link elmTupleFunction Normal
 hi def link elmTodo Todo


### PR DESCRIPTION
First attempt to get some syntax folding.  Kind of messy and not fully complete (missing if/then blocks and likely others) but covers top level definitions and case statements which was the biggest need for me.

To test, use my fork of elm-vim, e.g. with plug:

```
Plug 'dustinfarris/elm-vim', { 'branch': 'folding' }
```

and enable folding

```vim
autocmd FileType elm setlocal foldmethod=syntax
```

Here's a preview:

<img width="749" alt="screenshot 2017-10-17 15 03 16" src="https://user-images.githubusercontent.com/1087165/31686659-5d41d7be-b34c-11e7-8fb9-0eb89317e898.png">


I want to experiment with it for a while before considering for merge.  Any other feedback would be greatly appreciated — I am not a vim script expert.