### PR TITLE
Fix highlighting for multiline type annotation

### DIFF
--- a/syntax/elm.vim
+++ b/syntax/elm.vim
@@ -41,7 +41,7 @@ syn match elmInt "-\?\<\d\+\>\|0[xX][0-9a-fA-F]\+\>"
 syn match elmFloat "\(\<\d\+\.\d\+\>\)"
 
 " Identifiers
-syn match elmTopLevelDecl "^\s*[a-zA-Z][a-zA-z0-9_]*\('\)*\s\+:\s\+" contains=elmOperator
+syn match elmTopLevelDecl "^\s*[a-zA-Z][a-zA-z0-9_]*\('\)*\s\+:\(r\n\|\r\|\n\|\s\)\+" contains=elmOperator
 
 hi def link elmTopLevelDecl Function
 hi def link elmTupleFunction Normal


### PR DESCRIPTION
This fork add coloration to multiline type annotations. Changing

![screen shot 2017-10-23 at 7 03 39 pm](https://user-images.githubusercontent.com/8095741/31918960-fe7e1b4c-b824-11e7-8a6d-1c91ca7d3a3b.png)

to

![screen shot 2017-10-23 at 7 03 59 pm](https://user-images.githubusercontent.com/8095741/31918964-04964da6-b825-11e7-9aa9-afe2d728bfae.png)

