### PR TITLE
Improve GF to deal with prefixed functions & module aliases

### DIFF
--- a/autoload/elm/util.vim
+++ b/autoload/elm/util.vim
@@ -121,6 +121,10 @@ function! elm#util#GoToModule(name)
   " Relies on functions starting with a lower case letter
   let l:module_name = substitute(a:name, '\.[a-z][A-Za-z0-9_]\+$', '', '')
   let l:function_name = substitute(a:name, l:module_name . '\.', '', '')
+  let l:target = ""
+  if l:function_name != ""
+    let l:target = '^' . l:function_name . '\>'
+  endif
   let l:root = elm#FindRootDirectory()
 
   while 1
@@ -128,9 +132,9 @@ function! elm#util#GoToModule(name)
     let l:module_path = s:findModule(l:module_name, l:root, l:extension)
     if l:module_path != ""
       exec 'edit ' . fnameescape(l:module_path)
-      if l:function_name != ""
-        " Move cursor to function location
-        call search('^' . l:function_name . '\>')
+      if l:target != ""
+        " Move cursor to target location
+        call search(target)
       endif
       return
     endif
@@ -146,9 +150,9 @@ function! elm#util#GoToModule(name)
       let l:module_path = s:findModule(l:module_import_name, l:root, l:extension)
       if l:module_path != ""
         exec 'edit ' . fnameescape(l:module_path)
-        if l:function_name != ""
+        if l:target != ""
           " Move cursor to function location
-          call search('^' . l:function_name . '\>')
+          call search(target)
         endif
         return
       endif
@@ -162,6 +166,10 @@ function! elm#util#GoToModule(name)
     if l:module_name == l:new_module_name
       return s:error("Can't find module \"" . l:module_name . "\"")
     else
+      let l:type_name = substitute(l:module_name, l:new_module_name . '\.', '', '')
+      let l:type_regex = '^type \(alias \|\)' . l:type_name . '\( =\|\)$'
+      let l:union_regex = '^    \(=\||\) ' . l:type_name . '\( \|$\)'
+      let l:target = '\(' . l:type_regex . '\|' . l:union_regex . '\)'
       let l:module_name = l:new_module_name
     endif
   endwhile

--- a/autoload/elm/util.vim
+++ b/autoload/elm/util.vim
@@ -120,6 +120,7 @@ function! elm#util#GoToModule(name)
   " Strip trailing func name if it exists. So My.Module.func becomes My.Module
   " Relies on functions starting with a lower case letter
   let l:module_name = substitute(a:name, '\.[a-z][A-Za-z0-9_]\+$', '', '')
+  let l:function_name = substitute(a:name, l:module_name . '\.', '', '')
   let l:root = elm#FindRootDirectory()
 
   while 1
@@ -127,6 +128,10 @@ function! elm#util#GoToModule(name)
     let l:module_path = s:findModule(l:module_name, l:root, l:extension)
     if l:module_path != ""
       exec 'edit ' . fnameescape(l:module_path)
+      if l:function_name != ""
+        " Move cursor to function location
+        call search('^' . l:function_name . '\>')
+      endif
       return
     endif
 
@@ -141,6 +146,10 @@ function! elm#util#GoToModule(name)
       let l:module_path = s:findModule(l:module_import_name, l:root, l:extension)
       if l:module_path != ""
         exec 'edit ' . fnameescape(l:module_path)
+        if l:function_name != ""
+          " Move cursor to function location
+          call search('^' . l:function_name . '\>')
+        endif
         return
       endif
     endif

--- a/autoload/elm/util.vim
+++ b/autoload/elm/util.vim
@@ -116,7 +116,8 @@ function! elm#util#GoToModule(name)
   else
     let l:extension = '.js'
   endif
-  let l:rel_path = substitute(a:name, '\.', '/', 'g') . l:extension
+  let l:module_name = substitute(a:name, '\.[a-z][A-Za-z0-9_]\+$', '', '')
+  let l:rel_path = substitute(l:module_name, '\.', '/', 'g') . l:extension
   let l:root = elm#FindRootDirectory()
 
   let l:module_file = s:findLocalModule(l:rel_path, l:root)

--- a/autoload/elm/util.vim
+++ b/autoload/elm/util.vim
@@ -135,6 +135,8 @@ function! elm#util#GoToModule(name)
       if l:target != ""
         " Move cursor to target location
         call search(target)
+        " Center screen on line
+        exec "normal z."
       endif
       return
     endif
@@ -153,6 +155,8 @@ function! elm#util#GoToModule(name)
         if l:target != ""
           " Move cursor to function location
           call search(target)
+          " Center screen on line
+          exec "normal z."
         endif
         return
       endif

--- a/autoload/elm/util.vim
+++ b/autoload/elm/util.vim
@@ -131,12 +131,12 @@ function! elm#util#GoToModule(name)
   else
     " We can't find the module name, so see if it is a module alias by looking
     " for ' as M ' where M is our token
-    let l:line = search(' as ' . l:module_name . ' ', 'nw')
+    let l:line = search(' as ' . l:module_name . '\( \|$\)', 'nw')
     if line
       let l:contents = getline(line)
 
       " Convert 'import My.Module as MM ' to 'My.Module' to repeat the lookup
-      let l:module_name = substitute(substitute(l:contents, 'import ', '', ''), ' as ' . l:module_name . ' .*', '', '')
+      let l:module_name = substitute(substitute(l:contents, 'import ', '', ''), ' as .*', '', '')
       let l:rel_path = substitute(l:module_name, '\.', '/', 'g') . l:extension
 
       let l:module_file = s:findLocalModule(l:rel_path, l:root)

--- a/autoload/elm/util.vim
+++ b/autoload/elm/util.vim
@@ -116,19 +116,20 @@ function! elm#util#GoToModule(name)
   else
     let l:extension = '.js'
   endif
+
   " Strip trailing func name if it exists. So My.Module.func becomes My.Module
+  " Relies on functions starting with a lower case letter
   let l:module_name = substitute(a:name, '\.[a-z][A-Za-z0-9_]\+$', '', '')
-  let l:rel_path = substitute(l:module_name, '\.', '/', 'g') . l:extension
   let l:root = elm#FindRootDirectory()
 
-  let l:module_file = s:findLocalModule(l:rel_path, l:root)
-  if !filereadable(l:module_file)
-    let l:module_file = s:findDependencyModule(l:rel_path, l:root)
-  endif
+  while 1
 
-  if filereadable(l:module_file)
-    exec 'edit ' . fnameescape(l:module_file)
-  else
+    let l:module_path = s:findModule(l:module_name, l:root, l:extension)
+    if l:module_path != ""
+      exec 'edit ' . fnameescape(l:module_path)
+      return
+    endif
+
     " We can't find the module name, so see if it is a module alias by looking
     " for ' as M ' where M is our token
     let l:line = search(' as ' . l:module_name . '\( \|$\)', 'nw')
@@ -136,22 +137,39 @@ function! elm#util#GoToModule(name)
       let l:contents = getline(line)
 
       " Convert 'import My.Module as MM ' to 'My.Module' to repeat the lookup
-      let l:module_name = substitute(substitute(l:contents, 'import ', '', ''), ' as .*', '', '')
-      let l:rel_path = substitute(l:module_name, '\.', '/', 'g') . l:extension
-
-      let l:module_file = s:findLocalModule(l:rel_path, l:root)
-      if !filereadable(l:module_file)
-        let l:module_file = s:findDependencyModule(l:rel_path, l:root)
+      let l:module_import_name = substitute(substitute(l:contents, 'import ', '', ''), ' as .*', '', '')
+      let l:module_path = s:findModule(l:module_import_name, l:root, l:extension)
+      if l:module_path != ""
+        exec 'edit ' . fnameescape(l:module_path)
+        return
       endif
-
-      if filereadable(l:module_file)
-        exec 'edit ' . fnameescape(l:module_file)
-      else
-        return s:error("Can't find module \"" . l:module_name . "\"")
-      endif
-    else
-      return s:error("Can't find module \"" . a:name . "\"")
     endif
+
+    " Strip the last segment off and try again as we might be over a string
+    " that is My.Module.Type as types start with capital letters and so are
+    " indistinguishable from modules
+    let l:new_module_name = substitute(l:module_name, '\.[^\.]*$', '', '')
+
+    if l:module_name == l:new_module_name
+      return s:error("Can't find module \"" . l:module_name . "\"")
+    else
+      let l:module_name = l:new_module_name
+    endif
+  endwhile
+endfunction
+
+function! s:findModule(module_name, root, extension)
+  let l:rel_path = substitute(a:module_name, '\.', '/', 'g') . a:extension
+
+  let l:module_file = s:findLocalModule(l:rel_path, a:root)
+  if !filereadable(l:module_file)
+    let l:module_file = s:findDependencyModule(l:rel_path, a:root)
+  endif
+
+  if filereadable(l:module_file)
+    return l:module_file
+  else
+    return ""
   endif
 endfunction
 


### PR DESCRIPTION
This is pretty much the first vim script I've ever written so please feel free to change it.

Otherwise the intention is for `gf` to work for examples like `My.Module.func` and `MM` where `MM` is defined by `import My.Module as MM`. Also works for `MM.func`.

