### PR TITLE
Added the ability to use a differently-named elm-format binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ let g:elm_browser_command = ""
 let g:elm_detailed_complete = 0
 let g:elm_format_autosave = 1
 let g:elm_format_fail_silently = 0
+let g:elm_format_binary = 'elm-format'
 let g:elm_setup_keybindings = 1
 ```
 

--- a/autoload/elm.vim
+++ b/autoload/elm.vim
@@ -40,7 +40,7 @@ endf
 " Vim command to format Elm files with elm-format
 function! elm#Format() abort
 	" check for elm-format
-	if elm#util#CheckBin('elm-format', 'https://github.com/avh4/elm-format') ==# ''
+	if elm#util#CheckBin(g:elm_format_binary, 'https://github.com/avh4/elm-format') ==# ''
 		return
 	endif
 
@@ -61,7 +61,7 @@ function! elm#Format() abort
 	call writefile(getline(1, '$'), l:tmpname)
 
 	" call elm-format on the temporary file
-	let l:out = system('elm-format ' . l:tmpname . ' --output ' . l:tmpname)
+	let l:out = system(g:elm_format_binary . ' ' . l:tmpname . ' --output ' . l:tmpname)
 
 	" if there is no error
 	if v:shell_error == 0

--- a/doc/elm-vim.txt
+++ b/doc/elm-vim.txt
@@ -218,10 +218,10 @@ This setting toggles whether format errors show be display.
 
                                                         *'g:elm_format_binary'*
 
-This setting stores the name of the elm-format binary. Defaults to
+This setting stores the name/path of the elm-format binary. Defaults to
 'elm-format'. Allows the use of version-specific elm-format binaries.
 >
-  let g:elm-format_binary = 'elm-format-0.18'
+  let g:elm_format_binary = 'elm-format-0.18'
 <
 
 

--- a/doc/elm-vim.txt
+++ b/doc/elm-vim.txt
@@ -216,6 +216,14 @@ This setting toggles whether format errors show be display.
   let g:elm_format_fail_silently = 0
 <
 
+                                                        *'g:elm_format_binary'*
+
+This setting stores the name of the elm-format binary. Defaults to
+'elm-format'. Allows the use of version-specific elm-format binaries.
+>
+  let g:elm-format_binary = 'elm-format-0.18'
+<
+
 
 ===============================================================================
 TROUBLESHOOTING                                           *elm-troubleshooting*

--- a/plugin/elm.vim
+++ b/plugin/elm.vim
@@ -4,6 +4,12 @@ endif
 
 let g:loaded_elm = 1
 
+" Default settings
+if !exists('g:elm_format_binary')
+    let g:elm_format_binary = 'elm-format'
+endif
+
+
 " Mappings
 nnoremap <silent> <Plug>(elm-make) :<C-u>call elm#Make()<CR>
 nnoremap <silent> <Plug>(elm-make-main) :<C-u>call elm#Make("Main.elm")<CR>


### PR DESCRIPTION
On macOS' homebrew, elm-format is installed as two separate binaries:
  - elm-format-0.17
  - elm-format-0.18

elm-vim only ever looked for 'elm-format', but now the name of the
binary can be overridden by setting g:elm_format_binary.