### PR TITLE
Add ElmInstallExecutables command

### DIFF
--- a/autoload/elm.vim
+++ b/autoload/elm.vim
@@ -376,3 +376,29 @@ function! s:ExecuteInRoot(cmd) abort
 
 	return l:out
 endfunction
+
+" Install executables
+function! elm#InstallExecutables() abort
+	let l:packages = [
+		    \ 'elm',
+		    \ 'elm-test',
+		    \ 'elm-oracle',
+		    \ 'elm-format',
+		    \]
+
+	if executable('npm')
+		for l:package in l:packages
+			let l:cmd = join(['npm', 'install', '-g', l:package])
+			try
+				let l:out = system(l:cmd)
+			catch
+				call elm#util#EchoWarning('', l:out)
+				break
+			finally
+				call elm#util#EchoSuccess('', l:out)
+			endtry
+		endfor
+	else
+		call elm#util#EchoWarning('', 'npm is required to execute this command.')
+	endif
+endfunction

--- a/ftplugin/elm.vim
+++ b/ftplugin/elm.vim
@@ -49,6 +49,7 @@ command -buffer ElmErrorDetail call elm#ErrorDetail()
 command -buffer ElmShowDocs call elm#ShowDocs()
 command -buffer ElmBrowseDocs call elm#BrowseDocs()
 command -buffer ElmFormat call elm#Format()
+command! ElmInstallExecutables call elm#InstallExecutables()
 
 if get(g:, 'elm_setup_keybindings', 1)
   nmap <buffer> <LocalLeader>m <Plug>(elm-make)


### PR DESCRIPTION
I added a command to install required npm packages. It is inspired by vim-go's `GoInstallBinaries` command.  
This is the simplest implementation of `ElmInstallExecutables`, just calling system commands.

I recommend to merge #142 before merging this PR because I use `command!` instead of `command` in the code.