### PR TITLE
Added the option to enable to use elm-tool binaries at local node_modules

### DIFF
--- a/autoload/elm.vim
+++ b/autoload/elm.vim
@@ -109,8 +109,9 @@ endf
 
 " Query elm-oracle and open the docs for the word under the cursor.
 function! elm#BrowseDocs() abort
+  let l:binpath = elm#util#CleansingElmToolPath('elm-oracle')
 	" check for the elm-oracle binary
-	if elm#util#CheckBin('elm-oracle', 'https://github.com/elmcast/elm-oracle') ==# ''
+	if elm#util#CheckBin(l:binpath, 'https://github.com/elmcast/elm-oracle') ==# ''
 		return
 	endif
 
@@ -128,7 +129,7 @@ endf
 function! elm#Syntastic(input) abort
 	let l:fixes = []
 
-	let l:bin = 'elm-make'
+  let l:bin = elm#util#CleansingElmToolPath('elm-make')
 	let l:format = '--report=json'
 	let l:input = shellescape(a:input)
 	let l:output = '--output=' . shellescape(syntastic#util#DevNull())
@@ -158,16 +159,15 @@ function! elm#Syntastic(input) abort
 	return l:fixes
 endf
 
-function! elm#Build(input, output, show_warnings) abort
+function! elm#Build(bin, input, output, show_warnings) abort
 	let s:errors = []
 	let l:fixes = []
 	let l:rawlines = []
 
-	let l:bin = 'elm-make'
 	let l:format = '--report=json'
 	let l:input = shellescape(a:input)
 	let l:output = '--output=' . shellescape(a:output)
-	let l:command = l:bin . ' ' . l:format  . ' ' . l:input . ' ' . l:output
+	let l:command = a:bin . ' ' . l:format  . ' ' . l:input . ' ' . l:output
 	let l:reports = s:ExecuteInRoot(l:command)
 
 	for l:report in split(l:reports, '\n')
@@ -213,14 +213,15 @@ endf
 
 " Make the given file, or the current file if none is given.
 function! elm#Make(...) abort
-	if elm#util#CheckBin('elm-make', 'http://elm-lang.org/install') ==# ''
+  let l:binpath = elm#util#CleansingElmToolPath('elm-make')
+	if elm#util#CheckBin(l:binpath, 'http://elm-lang.org/install') ==# ''
 		return
 	endif
 
 	call elm#util#Echo('elm-make:', 'building...')
 
 	let l:input = (a:0 == 0) ? expand('%:p') : a:1
-	let l:fixes = elm#Build(l:input, g:elm_make_output_file, g:elm_make_show_warnings)
+	let l:fixes = elm#Build(l:binpath, l:input, g:elm_make_output_file, g:elm_make_show_warnings)
 
 	if len(l:fixes) > 0
 		call elm#util#EchoWarning('', 'found ' . len(l:fixes) . ' errors')
@@ -257,8 +258,9 @@ endf
 
 " Open the elm repl in a subprocess.
 function! elm#Repl() abort
+  let l:binpath = elm#util#CleansingElmToolPath('elm-repl')
 	" check for the elm-repl binary
-	if elm#util#CheckBin('elm-repl', 'http://elm-lang.org/install') ==# ''
+	if elm#util#CheckBin(l:binpath, 'http://elm-lang.org/install') ==# ''
 		return
 	endif
 
@@ -270,7 +272,7 @@ function! elm#Repl() abort
 endf
 
 function! elm#Oracle(filepath, word) abort
-	let l:bin = 'elm-oracle'
+  let l:bin = elm#util#CleansingElmToolPath('elm-oracle'),
 	let l:filepath = shellescape(a:filepath)
 	let l:word = shellescape(a:word)
 	let l:command = l:bin . ' ' . l:filepath . ' ' . l:word
@@ -328,16 +330,17 @@ endf
 " Otherwise run elm-test in the root of your project which deafults to
 " running 'elm-test tests/TestRunner'.
 function! elm#Test() abort
-	if elm#util#CheckBin('elm-test', 'https://github.com/rtfeldman/node-elm-test') ==# ''
+  let l:binpath = elm#util#CleansingElmToolPath('elm-test')
+	if elm#util#CheckBin(binpath, 'https://github.com/rtfeldman/node-elm-test') ==# ''
 		return
 	endif
 
 	if match(getline(1, '$'), 'consoleRunner') < 0
-		let l:out = s:ExecuteInRoot('elm-test')
+		let l:out = s:ExecuteInRoot(l:binpath)
 		call elm#util#EchoSuccess('elm-test', l:out)
 	else
 		let l:filepath = shellescape(expand('%:p'))
-		let l:out = s:ExecuteInRoot('elm-test ' . l:filepath)
+		let l:out = s:ExecuteInRoot(l:binpath . ' ' . l:filepath)
 		call elm#util#EchoSuccess('elm-test', l:out)
 	endif
 endf

--- a/autoload/elm.vim
+++ b/autoload/elm.vim
@@ -39,8 +39,9 @@ endf
 
 " Vim command to format Elm files with elm-format
 function! elm#Format() abort
+  let l:binpath = elm#util#CleansingElmToolPath('elm-format')
 	" check for elm-format
-	if elm#util#CheckBin('elm-format', 'https://github.com/avh4/elm-format') ==# ''
+	if elm#util#CheckBin(binpath, 'https://github.com/avh4/elm-format') ==# ''
 		return
 	endif
 
@@ -61,7 +62,7 @@ function! elm#Format() abort
 	call writefile(getline(1, '$'), l:tmpname)
 
 	" call elm-format on the temporary file
-	let l:out = system('elm-format ' . l:tmpname . ' --output ' . l:tmpname)
+	let l:out = system(l:binpath . ' ' . l:tmpname . ' --output ' . l:tmpname)
 
 	" if there is no error
 	if v:shell_error == 0

--- a/autoload/elm/util.vim
+++ b/autoload/elm/util.vim
@@ -172,3 +172,11 @@ function! s:error(msg)
 	echohl NONE
 	let v:errmsg = a:msg
 endfunction
+
+
+function! elm#util#CleansingElmToolPath(tool_name) abort
+  if g:elm_local_bin == 1
+    return './node_modules/.bin/' . a:tool_name
+  endif
+  return a:tool_name
+endfunction

--- a/doc/elm-vim.txt
+++ b/doc/elm-vim.txt
@@ -216,6 +216,11 @@ This setting toggles whether format errors show be display.
   let g:elm_format_fail_silently = 0
 <
 
+                                                 *'g:elm_local_bin'*
+
+This setting toggles whether your elm tools binary as global or local.
+>
+  let g:elm_local_bin = 0
 
 ===============================================================================
 TROUBLESHOOTING                                           *elm-troubleshooting*

--- a/ftplugin/elm.vim
+++ b/ftplugin/elm.vim
@@ -35,6 +35,10 @@ if !exists('g:elm_setup_keybindings')
 	let g:elm_setup_keybindings = 1
 endif
 
+if !exists('g:elm_local_bin')
+	let g:elm_local_bin = 0
+endif
+
 setlocal omnifunc=elm#Complete
 
 setlocal comments=:--


### PR DESCRIPTION
Hi, I love this plugin so much. 😍 

I try to add `g:elm_local_bin` to enable to use local binaries.
I mean `local` is `elm-xxx is installed to node_modules which is at project root`.
