### PR TITLE
Cleanup commands on plugin unload

### DIFF
--- a/ftplugin/elm.vim
+++ b/ftplugin/elm.vim
@@ -41,14 +41,26 @@ setlocal comments=:--
 setlocal commentstring=--\ %s
 
 " Commands
-command! -buffer -nargs=? -complete=file ElmMake call elm#Make(<f-args>)
-command! -buffer ElmMakeMain call elm#Make("Main.elm")
-command! -buffer -nargs=? -complete=file ElmTest call elm#Test(<f-args>)
-command! -buffer ElmRepl call elm#Repl()
-command! -buffer ElmErrorDetail call elm#ErrorDetail()
-command! -buffer ElmShowDocs call elm#ShowDocs()
-command! -buffer ElmBrowseDocs call elm#BrowseDocs()
-command! -buffer ElmFormat call elm#Format()
+command -buffer -nargs=? -complete=file ElmMake call elm#Make(<f-args>)
+command -buffer ElmMakeMain call elm#Make("Main.elm")
+command -buffer -nargs=? -complete=file ElmTest call elm#Test(<f-args>)
+command -buffer ElmRepl call elm#Repl()
+command -buffer ElmErrorDetail call elm#ErrorDetail()
+command -buffer ElmShowDocs call elm#ShowDocs()
+command -buffer ElmBrowseDocs call elm#BrowseDocs()
+command -buffer ElmFormat call elm#Format()
+
+" Commands cleanup
+let b:undo_ftplugin = "
+      \ delcommand ElmMake
+      \|delcommand ElmMakeMain
+      \|delcommand ElmTest
+      \|delcommand ElmRepl
+      \|delcommand ElmErrorDetail
+      \|delcommand ElmShowDocs
+      \|delcommand ElmBrowseDocs
+      \|delcommand ElmFormat
+      \"
 
 if get(g:, 'elm_setup_keybindings', 1)
   nmap <buffer> <LocalLeader>m <Plug>(elm-make)


### PR DESCRIPTION
Fixes #123. Possible better solution than #144.

Thank you @tpope and others for explaining the issue and fix.

Tested on macOS 10.13.4 with Vim (8.0.1750) and Neovim (0.2.2).