### PR TITLE
Multiline type declaration highlighting

### DIFF
--- a/syntax/elm.vim
+++ b/syntax/elm.vim
@@ -41,7 +41,7 @@ syn match elmInt "-\?\<\d\+\>\|0[xX][0-9a-fA-F]\+\>"
 syn match elmFloat "\(\<\d\+\.\d\+\>\)"
 
 " Identifiers
-syn match elmTopLevelDecl "^\s*[a-zA-Z][a-zA-z0-9_]*\('\)*\s\+:\s\+" contains=elmOperator
+syn match elmTopLevelDecl "^\s*[a-zA-Z][a-zA-z0-9_]*\('\)*\s\+:\(\r\n\|\r\|\n\|\s\)\+" contains=elmOperator
 
 " Folding
 syn region elmTopLevelTypedef start="type" end="\n\(\n\n\)\@=" contains=ALL fold


### PR DESCRIPTION
This just updates the syntax highlighting for multiline type declarations from
<img width="196" alt="screen shot 2018-06-13 at 22 32 07" src="https://user-images.githubusercontent.com/8095741/41391753-c78956a0-6f59-11e8-9c66-de129b540315.png">
To
<img width="170" alt="screen shot 2018-06-13 at 22 32 35" src="https://user-images.githubusercontent.com/8095741/41391761-cbddfcba-6f59-11e8-87c6-6b6f65d28627.png">
