### PR TITLE
Added setting to control the path of `elm-format`

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ let g:elm_browser_command = ""
 let g:elm_detailed_complete = 0
 let g:elm_format_autosave = 1
 let g:elm_format_fail_silently = 0
+let g:elm_format_command = "elm-format"
 let g:elm_setup_keybindings = 1
 ```
 

--- a/autoload/elm.vim
+++ b/autoload/elm.vim
@@ -40,7 +40,7 @@ endf
 " Vim command to format Elm files with elm-format
 function! elm#Format() abort
 	" check for elm-format
-	if elm#util#CheckBin('elm-format', 'https://github.com/avh4/elm-format') ==# ''
+	if elm#util#CheckBin(g:elm_format_command, 'https://github.com/avh4/elm-format') ==# ''
 		return
 	endif
 
@@ -61,7 +61,7 @@ function! elm#Format() abort
 	call writefile(getline(1, '$'), l:tmpname)
 
 	" call elm-format on the temporary file
-	let l:out = system('elm-format ' . l:tmpname . ' --output ' . l:tmpname)
+	let l:out = system(g:elm_format_command . ' ' . l:tmpname . ' --output ' . l:tmpname)
 
 	" if there is no error
 	if v:shell_error == 0

--- a/doc/elm-vim.txt
+++ b/doc/elm-vim.txt
@@ -216,6 +216,13 @@ This setting toggles whether format errors show be display.
   let g:elm_format_fail_silently = 0
 <
 
+                                                 *'g:elm_format_command'*
+
+This setting changes the command used to run elm-format.
+>
+  let g:elm_format_command = "elm-format"
+<
+
 
 ===============================================================================
 TROUBLESHOOTING                                           *elm-troubleshooting*

--- a/ftplugin/elm.vim
+++ b/ftplugin/elm.vim
@@ -31,6 +31,10 @@ if !exists('g:elm_format_fail_silently')
     let g:elm_format_fail_silently = 0
 endif
 
+if !exists('g:elm_format_command')
+	let g:elm_format_command = "elm-format"
+endif
+
 if !exists('g:elm_setup_keybindings')
 	let g:elm_setup_keybindings = 1
 endif


### PR DESCRIPTION
Some distributions of `elm-format` (e.g. Homebrew on Mac) give the
executable(s) names such as `elm-format-0.19`. Previously, the plugin
would try to run `elm-format` or else fail. Now, I have added
`g:elm_format_command` which can be set to any command/path/etc. so
`elm-format` can run even if installed under a weird path.