### PR TITLE
Add elm.json fallback to FindRootDirectory

### DIFF
--- a/autoload/elm.vim
+++ b/autoload/elm.vim
@@ -347,11 +347,14 @@ function! elm#FindRootDirectory() abort
 	if empty(l:elm_root)
 		let l:current_file = expand('%:p')
 		let l:dir_current_file = fnameescape(fnamemodify(l:current_file, ':h'))
-		let l:match = findfile('elm-package.json', l:dir_current_file . ';')
-		if empty(l:match)
-			let l:elm_root = ''
+		let l:old_match = findfile('elm-package.json', l:dir_current_file . ';')
+		let l:new_match = findfile('elm.json', l:dir_current_file . ';')
+		if !empty(l:new_match)
+			let l:elm_root = fnamemodify(l:new_match, ':p:h')
+		elseif !empty(l:old_match)
+			let l:elm_root = fnamemodify(l:old_match, ':p:h')
 		else
-			let l:elm_root = fnamemodify(l:match, ':p:h')
+			let l:elm_root = ''
 		endif
 
 		if !empty(l:elm_root)


### PR DESCRIPTION
Was running into an issue with `:ElmTest` in elm 0.19.0 where it was unable to find the root directory. Did a little digging, and found that `elm#FindRootDirectory` only looks for `elm-package.json`, and not `elm.json`.

So I added a fallback so that if an `elm-package.json` cannot be found, `FindRootDirectory` will look for an `elm.json` file before returning an empty string. After `Plug`ing my forked repo, this fix appears to have the desired behavior.

I'm a total vimscript noob, though, so please let me know if anything looks off.