### PR TITLE
fix elm make command to utilize the new elm make rather than elm-make

### DIFF
--- a/autoload/elm.vim
+++ b/autoload/elm.vim
@@ -127,11 +127,12 @@ endf
 function! elm#Syntastic(input) abort
 	let l:fixes = []
 
-	let l:bin = 'elm-make'
+	let l:bin = 'elm'
+	let l:subcommand = 'make'
 	let l:format = '--report=json'
 	let l:input = shellescape(a:input)
 	let l:output = '--output=' . shellescape(syntastic#util#DevNull())
-	let l:command = l:bin . ' ' . l:format  . ' ' . l:input . ' ' . l:output
+	let l:command = l:bin . ' ' . l:subcommand . ' ' . l:format  . ' ' . l:input . ' ' . l:output
 	let l:reports = s:ExecuteInRoot(l:command)
 
 	for l:report in split(l:reports, '\n')
@@ -162,11 +163,12 @@ function! elm#Build(input, output, show_warnings) abort
 	let l:fixes = []
 	let l:rawlines = []
 
-	let l:bin = 'elm-make'
+	let l:bin = 'elm'
+	let l:subcommand = 'make'
 	let l:format = '--report=json'
 	let l:input = shellescape(a:input)
 	let l:output = '--output=' . shellescape(a:output)
-	let l:command = l:bin . ' ' . l:format  . ' ' . l:input . ' ' . l:output
+	let l:command = l:bin . ' ' . l:subcommand . ' ' . l:format  . ' ' . l:input . ' ' . l:output
 	let l:reports = s:ExecuteInRoot(l:command)
 
 	for l:report in split(l:reports, '\n')
@@ -212,11 +214,11 @@ endf
 
 " Make the given file, or the current file if none is given.
 function! elm#Make(...) abort
-	if elm#util#CheckBin('elm-make', 'http://elm-lang.org/install') ==# ''
+	if elm#util#CheckBin('elm', 'http://elm-lang.org/install') ==# ''
 		return
 	endif
 
-	call elm#util#Echo('elm-make:', 'building...')
+	call elm#util#Echo('elm make:', 'building...')
 
 	let l:input = (a:0 == 0) ? expand('%:p') : a:1
 	let l:fixes = elm#Build(l:input, g:elm_make_output_file, g:elm_make_show_warnings)
@@ -341,7 +343,7 @@ function! elm#Test() abort
 	endif
 endf
 
-" Returns the closest parent with an elm-package.json file.
+" Returns the closest parent with an elm-package.json or elm.json file.
 function! elm#FindRootDirectory() abort
 	let l:elm_root = getbufvar('%', 'elmRoot')
 	if empty(l:elm_root)

--- a/doc/elm-vim.txt
+++ b/doc/elm-vim.txt
@@ -66,7 +66,7 @@ plugins.
     Copy all of the files into your `~/.vim` directory
 <
 
-Please be sure all necessary binaries are installed (such as `elm-make`,
+Please be sure all necessary binaries are installed (such as `elm`,
 `elm-doc`, `elm-reactor`, etc..) from http://elm-lang.org/. You may also want
 to install `elm-test` with 'npm install -g elm-test' if you want to run unit
 tests from within vim.
@@ -77,17 +77,17 @@ COMMANDS                                                         *elm-commands*
 
 :ElmMake [file]
 
-    ElmMake calls `elm-make` with the given {file}. If no {file} is given
+    ElmMake calls `elm make` with the given {file}. If no {file} is given
     it uses the current file being edited.
 
 :ElmMakeMain
 
-    ElmMakeMain attempts to call `elm-make` with "Main.elm".
+    ElmMakeMain attempts to call `elm make` with "Main.elm".
 
 :ElmTest [file]
 
     ElmTest calls `elm-test` with the given {file}. If no {file} is given
-    it runs it in the root of your project. 
+    it runs it in the root of your project.
 
 :ElmRepl
 
@@ -117,18 +117,18 @@ MAPPINGS                                                         *elm-mappings*
 
 elm-vim has several <Plug> keys which can be used to create custom mappings
 For example, to create a mapping that `elm make` the current file, create a
-mapping for the `(elm-make)` plug: >
+mapping for the `(elm make)` plug: >
 
-  au FileType elm nmap <leader>m <Plug>(elm-make)
+  au FileType elm nmap <leader>m <Plug>(elm make)
 
 As always, you can create more advanced mappings with |elm-commands|.
 Available <Plug> keys are:
 
-                                                                   *(elm-make)*
+                                                                   *(elm make)*
 
 Calls `elm make` for the current file
 
-                                                              *(elm-make-main)*
+                                                              *(elm make-main)*
 
 Calls `elm make` with "Main.elm"
 
@@ -164,7 +164,7 @@ found when running commands. By default it's enabled.
 <
                                                      *'g:elm_make_output_file'*
 
-This setting configures which file elm-make will compile to.
+This setting configures which file elm make will compile to.
 >
   let g:elm_make_output_file = "elm.js"
 <
@@ -220,15 +220,7 @@ This setting toggles whether format errors show be display.
 ===============================================================================
 TROUBLESHOOTING                                           *elm-troubleshooting*
 
-If you see something like:
->
-  command not found: elm-make
-<
-Make sure that you have correctly installed the elm platform from
-http://elm-lang.org.
-
-
-For all other issues, please see https://github.com/elmcast/elm-vim/issues.
+For issues, please see https://github.com/elmcast/elm-vim/issues.
 
 ===============================================================================
 CREDITS                                                           *elm-credits*

--- a/syntax_checkers/elm/elm_make.vim
+++ b/syntax_checkers/elm/elm_make.vim
@@ -9,7 +9,7 @@ let s:save_cpo = &cpoptions
 set cpoptions&vim
 
 function! SyntaxCheckers_elm_elm_IsAvailable() dict
-	return executable(substitute('elm-make', '^\s*\(.\{-}\)\s*$', '\1', ''))
+	return executable(substitute('elm', '^\s*\(.\{-}\)\s*$', '\1', ''))
 endfunction
 
 function! SyntaxCheckers_elm_elm_make_GetLocList() dict
@@ -19,7 +19,7 @@ endfunction
 call g:SyntasticRegistry.CreateAndRegisterChecker({
 			\ 'filetype': 'elm',
 			\ 'name': 'elm_make',
-			\ 'exec': 'elm-make'})
+			\ 'exec': 'elm make'})
 
 let &cpoptions = s:save_cpo
 unlet s:save_cpo


### PR DESCRIPTION
I figured I'd send this in to start a discussion. There are still some of the commands that don't work right yet because they are still relying on the old style of calling them. Specifically the ElmMakeMain and ElmRepl. Either way, I'd like to fully address #164.

I didn't know if you'd prefer those to all be in separate PR's and I wasn't positive if you wanted backwards compatibility if someone is using an old version of Elm. Either way, I'm happy to do seperate PR's, one large PR and to make a stab at making it backwards compatible as well.

:+1: 