### PR TITLE
Execute elm-format in Elm Root

### DIFF
--- a/autoload/elm.vim
+++ b/autoload/elm.vim
@@ -61,7 +61,7 @@ function! elm#Format() abort
 	call writefile(getline(1, '$'), l:tmpname)
 
 	" call elm-format on the temporary file
-	let l:out = system('elm-format ' . l:tmpname . ' --output ' . l:tmpname)
+	let l:out = s:ExecuteInRoot('elm-format ' . l:tmpname . ' --output ' . l:tmpname)
 
 	" if there is no error
 	if v:shell_error == 0


### PR DESCRIPTION
As mentioned in #166 there is still an issue when running `elm-format`.
This PR runs `elm-format` in the folder where elm(-package).json is found.