### PR TITLE
Replacement of source directory in findLocalModule

### DIFF
--- a/autoload/elm/util.vim
+++ b/autoload/elm/util.vim
@@ -132,15 +132,7 @@ function! elm#util#GoToModule(name)
 endfunction
 
 function! s:findLocalModule(rel_path, root)
-  let l:package_json = a:root . '/elm-package.json'
-  if exists('*json_decode')
-    let l:package = json_decode(readfile(l:package_json))
-    let l:source_roots = l:package['source-directories']
-  else
-    " This is a fallback for vim's which do not support json_decode.
-    " It simply only looks in the 'src' subdirectory and fails otherwise.
-    let l:source_roots = ['src']
-  end
+  let l:source_roots = ['src']
   for l:source_root in l:source_roots
     let l:file_path = a:root . '/' . l:source_root . '/' . a:rel_path
     if !filereadable(l:file_path)


### PR DESCRIPTION
The current implementation, that tried to parse json failed for 0.18 and 0.19.

This is a simple fix to solve #170. Using `src`, the default for both 0.18 and 0.19 will work in 98% of the cases.