### PR TITLE
Correct the leader type in keybinding

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,13 +53,13 @@ mappings. The following keybindings are provided by default:
 
 | Keybinding             | Description                                                         |
 | ---------------------- | ------------------------------------------------------------------- |
-| \<Leader>m              | Compile the current buffer.                                        |
-| \<Leader>b              | Compile the Main.elm file in the project.                          |
-| \<Leader>t              | Runs the tests of the current buffer or 'tests/TestRunner'.                              |
-| \<Leader>r              | Opens an elm repl in a subprocess.                                 |
-| \<Leader>e              | Shows the detail of the current error or warning.                  |
-| \<Leader>d              | Shows the type and docs for the word under the cursor.             |
-| \<Leader>w              | Opens the docs web page for the word under the cursor.             |
+| \<LocalLeader>m              | Compile the current buffer.                                        |
+| \<LocalLeader>b              | Compile the Main.elm file in the project.                          |
+| \<LocalLeader>t              | Runs the tests of the current buffer or 'tests/TestRunner'.                              |
+| \<LocalLeader>r              | Opens an elm repl in a subprocess.                                 |
+| \<LocalLeader>e              | Shows the detail of the current error or warning.                  |
+| \<LocalLeader>d              | Shows the type and docs for the word under the cursor.             |
+| \<LocalLeader>w              | Opens the docs web page for the word under the cursor.             |
 
 You can disable these mappings if you want to use your own.
 


### PR DESCRIPTION
Correct the readme -> keybindings to use `LocalLeader`, which is consistent with the implementation as seen here: https://github.com/ElmCast/elm-vim/blob/d22c0ba13afb554257a8c176962e2216cc18edd1/ftplugin/elm.vim#L66-L72.