### PR TITLE
Syntax: Fix top-level type def

### DIFF
--- a/syntax/elm.vim
+++ b/syntax/elm.vim
@@ -44,7 +44,7 @@ syn match elmFloat "\(\<\d\+\.\d\+\>\)"
 syn match elmTopLevelDecl "^\s*[a-zA-Z][a-zA-z0-9_]*\('\)*\s\+:\(\r\n\|\r\|\n\|\s\)\+" contains=elmOperator
 
 " Folding
-syn region elmTopLevelTypedef start="type" end="\n\(\n\n\)\@=" contains=ALL fold
+syn region elmTopLevelTypedef start="\<type\>" end="\n\(\n\n\)\@=" contains=ALL fold
 syn region elmTopLevelFunction start="^[a-zA-Z].\+\n[a-zA-Z].\+=" end="^\(\n\+\)\@=" contains=ALL fold
 syn region elmCaseBlock matchgroup=elmCaseBlockDefinition start="^\z\(\s\+\)\<case\>" end="^\z1\@!\W\@=" end="\(\n\n\z1\@!\)\@=" end="\n\z1\@!\(\n\n\)\@=" contains=ALL fold
 syn region elmCaseItemBlock start="^\z\(\s\+\).\+->$" end="^\z1\@!\W\@=" end="\(\n\n\z1\@!\)\@=" end="\(\n\z1\S\)\@=" contains=ALL fold


### PR DESCRIPTION
Why
---

This region was incorrectly activated for `type_` and other words containing `type`

How
---

Put word boundaries around `type`