### PR TITLE
Fix syntax highlighting for `case`

### DIFF
--- a/syntax/elm.vim
+++ b/syntax/elm.vim
@@ -46,7 +46,7 @@ syn match elmTopLevelDecl "^\s*[a-zA-Z][a-zA-z0-9_]*\('\)*\s\+:\(\r\n\|\r\|\n\|\
 " Folding
 syn region elmTopLevelTypedef start="type" end="\n\(\n\n\)\@=" contains=ALL fold
 syn region elmTopLevelFunction start="^[a-zA-Z].\+\n[a-zA-Z].\+=" end="^\(\n\+\)\@=" contains=ALL fold
-syn region elmCaseBlock matchgroup=elmCaseBlockDefinition start="^\z\(\s\+\)\<case\>" end="^\z1\@!\W\@=" end="\(\n\n\z1\@!\)\@=" end="\n\z1\@!\(\n\n\)\@=" contains=ALL fold
+syn region elmCaseBlock matchgroup=elmCaseBlockDefinition start="\<case\>" end="^\z1\@!\W\@=" end="\(\n\n\z1\@!\)\@=" end="\n\z1\@!\(\n\n\)\@=" contains=ALL fold
 syn region elmCaseItemBlock start="^\z\(\s\+\).\+->$" end="^\z1\@!\W\@=" end="\(\n\n\z1\@!\)\@=" end="\(\n\z1\S\)\@=" contains=ALL fold
 syn region elmLetBlock matchgroup=elmLetBlockDefinition start="\<let\>" end="\<in\>" contains=ALL fold
 


### PR DESCRIPTION
The keyword `case` wouldn't get highlighted properly when there was any non-whitespace character on the same line before it.

Often `elm-format` puts `case` on a new line, but not always, for example:

```elm
view x =
    div
        []
        (case x of
            [] ->
                text "foo"

            _ ->
                text "bar"
        )
```

*Note*: This PR might have some other effects on features I am not familiar with. The modified line is in a block of vim script with a comment saying _"Folding"_. It is possible my changes affect folding as well, and I am not entirely sure how to test that.