### PR TITLE
Set tabbing to the vim standard (2 spaces)

### DIFF
--- a/indent/elm.vim
+++ b/indent/elm.vim
@@ -8,6 +8,7 @@ let b:did_indent = 1
 
 " Local defaults
 setlocal expandtab
+setlocal shiftwidth=2 tabstop=2
 setlocal indentexpr=GetElmIndent()
 setlocal indentkeys+=0=else,0=if,0=of,0=import,0=then,0=type,0\|,0},0\],0),=-},0=in
 setlocal nolisp


### PR DESCRIPTION
Problem: When I use elm-vim out of the box it defaults to tab stops of 8 spaces, but the Elm standard is 2 spaces.

Workaround: As a workaround I added the following line to my `~/.vimrc` file:

```vim
autocmd FileType elm setlocal shiftwidth=2 tabstop=2
```

But that's a manual change.

Fix: The change submitted seems to fix this problem, and sets tab stops in `.elm` files to 2 spaces, regardless of the user's global settings.