### PR TITLE
Improve the highlighting of special characters (fixes #186)

### DIFF
--- a/syntax/elm.vim
+++ b/syntax/elm.vim
@@ -30,11 +30,11 @@ syn match elmLineComment "--.*" contains=elmTodo,@spell
 syn region elmComment matchgroup=elmComment start="{-|\=" end="-}" contains=elmTodo,elmComment,@spell fold
 
 " Strings
-syn match elmStringEscape "\\u[0-9a-fA-F]\{4}" contained
-syn match elmStringEscape "\\[nrfvbt\\\"]" contained
-syn region elmString start="\"" skip="\\\"" end="\"" contains=elmStringEscape,@spell
-syn region elmTripleString start="\"\"\"" skip="\\\"" end="\"\"\"" contains=elmStringEscape,@spell
-syn match elmChar "'[^'\\]'\|'\\.'\|'\\u[0-9a-fA-F]\{4}'"
+syn match elmSpecialChar "\\u[0-9a-fA-F]\{4}" contained
+syn match elmSpecialChar "\\[nrfvbt\\\"]" contained
+syn region elmString start="\"" skip="\\\"" end="\"" contains=elmSpecialChar,@spell
+syn region elmTripleString start="\"\"\"" skip="\\\"" end="\"\"\"" contains=elmSpecialChar,@spell
+syn match elmChar "'[^'\\]'\|'\\.'\|'\\u[0-9a-fA-F]\{4}'" contains=elmSpecialChar
 
 " Numbers
 syn match elmInt "-\?\<\d\+\>\|0[xX][0-9a-fA-F]\+\>"
@@ -63,7 +63,7 @@ hi def link elmLineComment Comment
 hi def link elmString String
 hi def link elmTripleString String
 hi def link elmChar String
-hi def link elmStringEscape Special
+hi def link elmSpecialChar Special
 hi def link elmInt Number
 hi def link elmFloat Float
 hi def link elmDelimiter Delimiter

--- a/syntax/elm.vim
+++ b/syntax/elm.vim
@@ -10,9 +10,6 @@ syn keyword elmAlias alias
 syn keyword elmTypedef contained type port
 syn keyword elmImport exposing as import module where
 
-" Operators
-syn match elmOperator contained "\([-!#$%`&\*\+./<=>\?@\\^|~:]\|\<_\>\)"
-
 " Types
 syn match elmType "\<[A-Z][0-9A-Za-z_'-]*"
 syn keyword elmNumberType number
@@ -39,6 +36,10 @@ syn match elmChar "'[^'\\]'\|'\\.'\|'\\u[0-9a-fA-F]\{4}'" contains=elmSpecialCha
 " Numbers
 syn match elmInt "-\?\<\d\+\>\|0[xX][0-9a-fA-F]\+\>"
 syn match elmFloat "\(\<\d\+\.\d\+\>\)"
+
+" Operators
+" Note: *elmOperator* must be matched after *elmSpecialChar*, because they overlap
+syn match elmOperator contained "\([-!#$%`&\*\+./<=>\?@\\^|~:]\|\<_\>\)"
 
 " Identifiers
 syn match elmTopLevelDecl "^\s*[a-zA-Z][a-zA-z0-9_]*\('\)*\s\+:\(\r\n\|\r\|\n\|\s\)\+" contains=elmOperator


### PR DESCRIPTION
* highlight special characters in character literals
* properly highlight lambdas starting with "special characters" (e.g. n, r, t)