### PR TITLE
fix elm repl command to utilize the new elm repl rather than elm-repl

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ let g:elm_setup_keybindings = 1
 
 * `:ElmTest` calls `elm-test` with the given file. If no file is given it runs it in the root of your project. 
 
-* `:ElmRepl` runs `elm-repl`, which will return to vim on exiting.
+* `:ElmRepl` runs `elm repl`, which will return to vim on exiting.
 
 * `:ElmErrorDetail` shows the detail of the current error in the quickfix window.
 

--- a/autoload/elm.vim
+++ b/autoload/elm.vim
@@ -258,15 +258,15 @@ endf
 
 " Open the elm repl in a subprocess.
 function! elm#Repl() abort
-	" check for the elm-repl binary
-	if elm#util#CheckBin('elm-repl', 'http://elm-lang.org/install') ==# ''
+	" check for the elm repl binary
+	if elm#util#CheckBin('elm', 'http://elm-lang.org/install') ==# ''
 		return
 	endif
 
 	if has('nvim')
-		term('elm-repl')
+		term(elm repl)
 	else
-		!elm-repl
+		!elm repl
 	endif
 endf
 

--- a/doc/elm-vim.txt
+++ b/doc/elm-vim.txt
@@ -136,7 +136,7 @@ Calls `elm make` with "Main.elm"
 
 Calls `elm test` with "Test[filename].elm"
 
-                                                                   *(elm-repl)*
+                                                                   *(elm repl)*
 
 Calls `elm repl` in a subprocess
 


### PR DESCRIPTION
Just like #168, change `elm-repl` to `elm repl`.