### PR TITLE
Fix auto-formatting on save breaking Parcel's watch mode

### DIFF
--- a/autoload/elm.vim
+++ b/autoload/elm.vim
@@ -67,12 +67,10 @@ function! elm#Format() abort
 	if v:shell_error == 0
 		try | silent undojoin | catch | endtry
 
-		" replace current file with temp file, then reload buffer
-		let l:old_fileformat = &fileformat
-		call rename(l:tmpname, expand('%'))
-		silent edit!
-		let &fileformat = l:old_fileformat
-		let &syntax = &syntax
+		" replace current buffer with buffer from temp file
+		%delete
+		exe 'read ' . l:tmpname
+		1delete
 	elseif g:elm_format_fail_silently == 0
 		call elm#util#EchoLater('EchoError', 'elm-format:', l:out)
 	endif


### PR DESCRIPTION
Hi,
as mentioned in #160 this is still an issue (tested with Parcel 1.12.4). Contrary to #96 this should not have any such ramifications.

I think in general this solution would be more robust than the rename-based solution with respect to file watches which are often inode based.

Would you need any additional information to merge this?